### PR TITLE
fix: service name

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-tracing"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2024"
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -43,6 +43,9 @@ Also, see .env.example
   **milliseconds**. Defaults to 1000ms, which is equivalent to 1 second.
 - `OTEL_ENVIRONMENT_NAME` - optional. Value for the `deployment.environment.
   name` resource key according to the OTEL conventions.
+- `OTEL_SERVICE_NAME` - optional. Value for the `service.name` resource key
+  according to the OTEL conventions. If set, this will override the default
+  service name taken from `CARGO_PKG_NAME`.
 - `TRACING_METRICS_PORT` - Which port to bind the the exporter to. If the variable is missing or unparseable, it defaults to 9000.
 - `TRACING_LOG_JSON` - If set, will enable JSON logging.
 


### PR DESCRIPTION
- Adds `OTEL_SERVICE_NAME` that overrides `CARGO_PKG_NAME` for the otel service name for more intuitive setup